### PR TITLE
examples: alternative trace viewers (review + focus)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ build/
 *.tgz
 .DS_Store
 .claude/
+
+# Example viewers — generated outputs
+examples/*-review.html
+examples/*-focus.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+
+### Added
+
+- `examples/` directory with two alternative HTML viewers for atom-graph exports
+  and a synthetic `example-trace.json` demonstrating the V-kills-H pattern.
+  - `render-review.mjs` — small graph in a left rail + stage-by-stage atom
+    content; verifications stage in focus.
+  - `render-focus.mjs` — verifications and conclusion only, full-bleed.
+  - Both consume the unchanged output of `atomcommands export` and additionally
+    honor optional `kills` / `confirms` fields on verification atoms to
+    highlight which hypotheses each verification eliminates or supports. The
+    default D3 viewer ignores these fields, so adding them is non-breaking.
+
 ## [3.0.0] — 2026-04-13
 
 Major UX refactor. Tool surface collapsed to 3, sessions added,

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,50 @@
+# Examples — alternative trace viewers
+
+Two standalone HTML renderers for AoT atom-graph exports. Read the JSON produced by `atomcommands export` and render a different visual than the default D3 force-graph in `src/visualization.ts`. Useful when a long-form text view reads better than an interactive graph — async review, documentation, or anywhere you want the atom content visible without clicking.
+
+Both renderers consume the export JSON unchanged, plus two optional fields on verification atoms:
+
+- `kills: string[]` — which hypotheses this verification eliminates
+- `confirms: string[]` — which hypotheses this verification supports
+
+The default D3 viewer ignores these. The viewers in this directory use them to highlight the killing-V → killed-H relationship.
+
+## Renderers
+
+### `render-review.mjs` — review viewer
+
+Atom graph in a left rail (small) + stage-by-stage atom content as the main column. Stages are stacked top-to-bottom: Premises → Reasoning → Hypotheses → Verifications → Conclusion. The Verifications stage gets a focus treatment (cyan accent + "in focus" pill). Killed hypotheses are dimmed. Killing verifications get a red accent and an explicit `× kills H2` badge.
+
+Use for full-trace review where you want both the structure and the content readable at a glance.
+
+```bash
+node examples/render-review.mjs examples/example-trace.json
+# wrote examples/example-trace-review.html
+```
+
+Open the resulting HTML in a browser, or convert to PNG via Playwright / similar.
+
+### `render-focus.mjs` — focus viewer
+
+Verifications + Conclusion only, full-bleed. A single-frame summary of what the trace caught and what survived. Each V atom prints as a card with a `× KILLS H2` or `✓ confirms H1` banner.
+
+```bash
+node examples/render-focus.mjs examples/example-trace.json
+# wrote examples/example-trace-focus.html
+```
+
+## Example data
+
+`example-trace.json` — a synthetic trace ("pick a database for query telemetry") that exercises all five atom types and demonstrates the V-kills-H pattern. Both renderers should produce sensible output from this file. Use it as a template when building your own.
+
+## Producing your own input JSON
+
+```text
+1. Run AoT-fast / AoT-full in your MCP-enabled session
+2. Call atomcommands export (optionally with a title)
+3. Save the returned `graph` object to disk as JSON
+4. (Optional) Add `kills` / `confirms` fields to your verification atoms
+   so the alternative viewers can highlight the V-kills-H relationships
+```
+
+If you don't add `kills` / `confirms`, the viewers still work — verifications just render as neutral verification atoms without the kill/confirm callouts.

--- a/examples/example-trace.json
+++ b/examples/example-trace.json
@@ -1,0 +1,91 @@
+{
+  "title": "Serverless function → Postgres connection strategy — V kills H2",
+  "nodes": [
+    {
+      "id": "P1",
+      "type": "premise",
+      "content": "A serverless function (Lambda / Workers / Cloud Functions) needs to query Postgres on each invocation. Pick a connection strategy.",
+      "confidence": 0.95,
+      "depth": 0
+    },
+    {
+      "id": "P2",
+      "type": "premise",
+      "content": "Traffic is bursty: 0 to 500 concurrent invocations within a few seconds. Average function runtime is around 100ms. Connection setup over TLS is 50-200ms.",
+      "confidence": 0.92,
+      "depth": 0
+    },
+    {
+      "id": "R1",
+      "type": "reasoning",
+      "content": "Postgres has a hard connection ceiling (default around 100). Every invocation needs a connection. Connection churn at burst is the failure mode to design for.",
+      "confidence": 0.88,
+      "depth": 1
+    },
+    {
+      "id": "R2",
+      "type": "reasoning",
+      "content": "Operational complexity matters. Adding a new component to the path (a proxy) introduces failure modes, observability surface, and another thing to upgrade.",
+      "confidence": 0.85,
+      "depth": 1
+    },
+    {
+      "id": "H1",
+      "type": "hypothesis",
+      "content": "Open a fresh connection per invocation. Simplest possible. Pays the 50-200ms TLS handshake every time.",
+      "confidence": 0.7,
+      "depth": 2
+    },
+    {
+      "id": "H2",
+      "type": "hypothesis",
+      "content": "Maintain a connection pool inside the function's container. Reuse connections across warm invocations of the same instance.",
+      "confidence": 0.7,
+      "depth": 2
+    },
+    {
+      "id": "H3",
+      "type": "hypothesis",
+      "content": "Put a connection proxy (RDS Proxy / PgBouncer) in front of Postgres. Functions talk to the proxy; the proxy multiplexes onto a small number of actual Postgres connections.",
+      "confidence": 0.7,
+      "depth": 2
+    },
+    {
+      "id": "V1",
+      "type": "verification",
+      "content": "H2 silently fails at burst. Each cold-start container gets its own pool, so 500 concurrent invocations create 500 separate pools — each holding N connections. That is exactly the pattern the pool was meant to prevent. Looks fine in dev; breaks at scale.",
+      "confidence": 0.93,
+      "depth": 3,
+      "kills": ["H2"]
+    },
+    {
+      "id": "V2",
+      "type": "verification",
+      "content": "H3 trades one operational component for predictable connection multiplexing. The proxy is the standard answer for this exact scaling shape, and the failure modes (proxy down, proxy lag) are well-understood.",
+      "confidence": 0.88,
+      "depth": 3,
+      "confirms": ["H3"]
+    },
+    {
+      "id": "C1",
+      "type": "conclusion",
+      "content": "H3 (connection proxy). H1 is acceptable for low-throughput functions but adds tail latency. H2 is the trap — feels right, fails on the burst case it's supposedly designed for. The smart-sounding option silently fails on its target case.",
+      "confidence": 0.87,
+      "depth": 4
+    }
+  ],
+  "links": [
+    {"source": "P1", "target": "R1"},
+    {"source": "P2", "target": "R1"},
+    {"source": "P1", "target": "R2"},
+    {"source": "R1", "target": "H1"},
+    {"source": "R1", "target": "H2"},
+    {"source": "R2", "target": "H2"},
+    {"source": "R1", "target": "H3"},
+    {"source": "R2", "target": "H3"},
+    {"source": "H2", "target": "V1"},
+    {"source": "H3", "target": "V2"},
+    {"source": "V1", "target": "C1"},
+    {"source": "V2", "target": "C1"}
+  ]
+}

--- a/examples/render-focus.mjs
+++ b/examples/render-focus.mjs
@@ -1,0 +1,333 @@
+// Focus viewer: just the Verifications + Conclusion stages of a trace,
+// full-bleed. A single-frame summary of what the trace caught and what survived.
+//
+// Usage:
+//   node examples/render-focus.mjs <input.json> [output.html]
+//
+// Same input shape as render-review.mjs: an `atomcommands export` graph,
+// with optional `kills` / `confirms` fields on verification atoms.
+import { readFileSync, writeFileSync } from 'node:fs';
+import { basename, dirname, join, resolve } from 'node:path';
+
+function escapeHtml(s) {
+  return String(s ?? '').replace(/[&<>"']/g, c => ({
+    '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+  }[c]));
+}
+
+function buildHtml(graph) {
+  const { title, nodes, links } = graph;
+
+  // Use explicit `kills` field on V atoms.
+  const killSet = new Set();
+  for (const v of nodes.filter(n => n.type === 'verification')) {
+    if (Array.isArray(v.kills) && v.kills.length > 0) killSet.add(v.id);
+  }
+
+  const verifications = nodes.filter(n => n.type === 'verification');
+  const conclusionAtom = nodes.find(n => n.type === 'conclusion');
+
+  const titleParts = title.split('—').map(s => s.trim());
+  const headlineTitle = titleParts[0] || title;
+  const subtitle = titleParts[1] || '';
+
+  function renderV(v) {
+    const isKilling = killSet.has(v.id);
+    const conf = Math.round((v.confidence ?? 0.7) * 100);
+    const targets = isKilling
+      ? (v.kills || [])
+      : (v.confirms || links.filter(l => l.target === v.id).map(l => l.source).filter(s => nodes.find(n => n.id === s && n.type === 'hypothesis')));
+    const killBadge = isKilling
+      ? `<div class="kill-banner"><span class="kill-banner__x">×</span> KILLS <strong>${targets.join(', ')}</strong></div>`
+      : `<div class="confirm-banner">✓ confirms ${targets.join(', ')}</div>`;
+    return `
+      <article class="atom atom--verification${isKilling ? ' atom--killing' : ''}">
+        <div class="atom__top">
+          <span class="atom__id">${escapeHtml(v.id)}</span>
+          <span class="atom__type">VERIFICATION</span>
+          <span class="atom__conf-text">${conf}%</span>
+        </div>
+        ${killBadge}
+        <p class="atom__content">${escapeHtml(v.content)}</p>
+      </article>
+    `;
+  }
+
+  function renderC(c) {
+    if (!c) return '';
+    const conf = Math.round((c.confidence ?? 0.7) * 100);
+    return `
+      <article class="atom atom--conclusion">
+        <div class="atom__top">
+          <span class="atom__id">${escapeHtml(c.id)}</span>
+          <span class="atom__type">CONCLUSION</span>
+          <span class="atom__conf-text">${conf}%</span>
+        </div>
+        <div class="conclusion-banner">WHAT SURVIVES</div>
+        <p class="atom__content atom__content--big">${escapeHtml(c.content)}</p>
+      </article>
+    `;
+  }
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>${escapeHtml(title)}</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+
+  :root {
+    --bg: #0a0e16;
+    --bg-elev: #11161f;
+    --bg-focus: #0f1c24;
+    --bg-finale: #0c1c18;
+    --border: rgba(255, 255, 255, 0.07);
+    --border-focus: rgba(34, 211, 238, 0.45);
+    --border-finale: rgba(52, 211, 153, 0.45);
+
+    --fg: #eef0f3;
+    --fg-secondary: #a8aeb8;
+    --fg-muted: #6c727b;
+    --fg-faint: #3a3f48;
+
+    --verification: #22d3ee;
+    --conclusion: #34d399;
+    --killed: #f87171;
+
+    --mono: 'SF Mono', 'Menlo', 'JetBrains Mono', monospace;
+    --sans: 'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Inter', sans-serif;
+  }
+
+  body {
+    background: var(--bg);
+    color: var(--fg);
+    font-family: var(--sans);
+    line-height: 1.5;
+    min-height: 100vh;
+    -webkit-font-smoothing: antialiased;
+    padding: 48px 56px;
+  }
+
+  .header {
+    margin-bottom: 32px;
+    display: flex;
+    align-items: baseline;
+    gap: 20px;
+  }
+  .header__title {
+    font-size: 24px;
+    font-weight: 600;
+    letter-spacing: -0.025em;
+  }
+  .header__sep { color: var(--fg-faint); }
+  .header__pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 14px;
+    border-radius: 5px;
+    background: rgba(248, 113, 113, 0.12);
+    color: var(--killed);
+    font-family: var(--mono);
+    font-size: 14px;
+    font-weight: 500;
+  }
+  .header__pill::before { content: '×'; font-weight: 700; font-size: 16px; }
+
+  .stage-label {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--fg-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.10em;
+    margin-bottom: 12px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+  .stage-label__chip {
+    width: 10px;
+    height: 10px;
+    border-radius: 2px;
+  }
+  .stage-label__chip--v { background: var(--verification); }
+  .stage-label__chip--c { background: var(--conclusion); }
+  .stage-label__hint {
+    color: var(--fg-faint);
+    font-size: 11px;
+    font-weight: 400;
+    text-transform: none;
+    letter-spacing: 0;
+    margin-left: auto;
+  }
+
+  .stack {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 20px;
+    margin-bottom: 36px;
+  }
+
+  .atom {
+    border-radius: 10px;
+    padding: 24px 28px;
+    border: 1px solid var(--border);
+    background: var(--bg-elev);
+  }
+
+  .atom--verification {
+    background: var(--bg-focus);
+    border-color: var(--border-focus);
+    box-shadow: 0 0 0 1px rgba(34, 211, 238, 0.12);
+  }
+  .atom--killing {
+    border-color: var(--killed);
+    box-shadow: 0 0 0 1px rgba(248, 113, 113, 0.20);
+  }
+  .atom--conclusion {
+    background: var(--bg-finale);
+    border-color: var(--border-finale);
+    box-shadow: 0 0 0 1px rgba(52, 211, 153, 0.18);
+  }
+
+  .atom__top {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 14px;
+  }
+  .atom__id {
+    font-family: var(--mono);
+    font-size: 14px;
+    font-weight: 600;
+    padding: 4px 10px;
+    border-radius: 4px;
+    background: rgba(255, 255, 255, 0.06);
+  }
+  .atom--verification .atom__id { color: var(--verification); }
+  .atom--conclusion .atom__id { color: var(--conclusion); background: rgba(52, 211, 153, 0.10); }
+
+  .atom__type {
+    font-family: var(--mono);
+    font-size: 11px;
+    font-weight: 500;
+    color: var(--fg-muted);
+    letter-spacing: 0.08em;
+  }
+  .atom__conf-text {
+    margin-left: auto;
+    font-family: var(--mono);
+    font-variant-numeric: tabular-nums;
+    font-size: 14px;
+    color: var(--fg-secondary);
+  }
+
+  .kill-banner {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 14px;
+    border-radius: 5px;
+    background: rgba(248, 113, 113, 0.13);
+    color: var(--killed);
+    font-family: var(--mono);
+    font-size: 13px;
+    font-weight: 600;
+    margin-bottom: 14px;
+    letter-spacing: 0.04em;
+  }
+  .kill-banner__x {
+    font-size: 18px;
+    line-height: 0.8;
+    font-weight: 700;
+  }
+  .kill-banner strong {
+    color: #fca5a5;
+    font-weight: 700;
+    margin-left: 2px;
+  }
+
+  .confirm-banner {
+    display: inline-flex;
+    align-items: center;
+    padding: 6px 12px;
+    border-radius: 4px;
+    background: rgba(34, 211, 238, 0.10);
+    color: var(--verification);
+    font-family: var(--mono);
+    font-size: 12px;
+    font-weight: 500;
+    margin-bottom: 14px;
+  }
+
+  .conclusion-banner {
+    display: inline-flex;
+    align-items: center;
+    padding: 6px 12px;
+    border-radius: 4px;
+    background: rgba(52, 211, 153, 0.13);
+    color: var(--conclusion);
+    font-family: var(--mono);
+    font-size: 12px;
+    font-weight: 600;
+    margin-bottom: 14px;
+    letter-spacing: 0.06em;
+  }
+
+  .atom__content {
+    color: var(--fg);
+    font-size: 18px;
+    line-height: 1.55;
+    max-width: 88ch;
+  }
+  .atom__content--big {
+    font-size: 20px;
+    font-weight: 450;
+    line-height: 1.55;
+  }
+</style>
+</head>
+<body>
+
+<header class="header">
+  <h1 class="header__title">${escapeHtml(headlineTitle)}</h1>
+  ${subtitle ? `<span class="header__sep">·</span><span class="header__pill">${escapeHtml(subtitle)}</span>` : ''}
+</header>
+
+<div class="stage-label">
+  <span class="stage-label__chip stage-label__chip--v"></span>
+  Verifications
+  <span class="stage-label__hint">where the V kills the H</span>
+</div>
+<div class="stack">
+  ${verifications.map(renderV).join('')}
+</div>
+
+<div class="stage-label">
+  <span class="stage-label__chip stage-label__chip--c"></span>
+  Conclusion
+  <span class="stage-label__hint">what survives</span>
+</div>
+<div class="stack">
+  ${renderC(conclusionAtom)}
+</div>
+
+</body>
+</html>`;
+}
+
+const [, , inputArg, outputArg] = process.argv;
+if (!inputArg) {
+  console.error('Usage: node render-focus.mjs <input.json> [output.html]');
+  process.exit(1);
+}
+
+const inputPath = resolve(inputArg);
+const outputPath = outputArg
+  ? resolve(outputArg)
+  : join(dirname(inputPath), basename(inputPath, '.json') + '-focus.html');
+
+const data = JSON.parse(readFileSync(inputPath, 'utf-8'));
+writeFileSync(outputPath, buildHtml(data));
+console.log(`wrote ${outputPath}`);

--- a/examples/render-review.mjs
+++ b/examples/render-review.mjs
@@ -1,0 +1,684 @@
+// Render an alternative AoT review viewer: small graph in a left rail,
+// stage-by-stage atom content as the main column, with the verifications
+// stage visually in focus.
+//
+// Usage:
+//   node examples/render-review.mjs <input.json> [output.html]
+//
+// <input.json> is the export from `atomcommands export` plus optional
+// `kills: ["H1"]` / `confirms: ["H1"]` fields on verification atoms.
+// If `output.html` is omitted, writes alongside the input as
+// `<basename>-review.html`.
+import { readFileSync, writeFileSync } from 'node:fs';
+import { basename, dirname, join, resolve } from 'node:path';
+
+const STAGES = [
+  { type: 'premise',      label: 'Premises',      blurb: 'Facts on the ground' },
+  { type: 'reasoning',    label: 'Reasoning',     blurb: 'Connecting the premises' },
+  { type: 'hypothesis',   label: 'Hypotheses',    blurb: 'Candidate options' },
+  { type: 'verification', label: 'Verifications', blurb: 'Pressure-testing each H' },
+  { type: 'conclusion',   label: 'Conclusion',    blurb: 'What survives' },
+];
+
+function escapeHtml(s) {
+  return String(s ?? '').replace(/[&<>"']/g, c => ({
+    '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+  }[c]));
+}
+
+function renderAtom(node, links, allNodes, killSet, killedHs) {
+  const conf = (node.confidence ?? 0.7);
+  const confPct = Math.round(conf * 100);
+  const deps = links.filter(l => l.target === node.id).map(l => l.source);
+  const depsStr = deps.length ? deps.join(', ') : null;
+
+  const isKillingV = killSet.has(node.id);
+  const isKilledH = killedHs.has(node.id);
+
+  // The H(s) this V kills (only meaningful if isKillingV)
+  const killTargets = isKillingV
+    ? links.filter(l => l.target === node.id).map(l => l.source).filter(s => allNodes.find(n => n.id === s && n.type === 'hypothesis'))
+    : [];
+
+  let killBadge = '';
+  if (isKillingV) {
+    killBadge = `<span class="kill-badge"><span class="kill-badge__arrow">×</span>kills <strong>${killTargets.join(', ')}</strong></span>`;
+  } else if (isKilledH) {
+    killBadge = `<span class="killed-badge">eliminated</span>`;
+  }
+
+  const stateClass = isKillingV ? ' atom--killing' : isKilledH ? ' atom--killed' : '';
+
+  return `
+    <article class="atom atom--${node.type}${stateClass}">
+      <div class="atom__rail">
+        <span class="atom__id">${escapeHtml(node.id)}</span>
+        <div class="atom__conf-bar" aria-label="confidence ${confPct}%">
+          <div class="atom__conf-fill" style="width:${confPct}%"></div>
+        </div>
+        <span class="atom__conf-text">${confPct}<span class="pct">%</span></span>
+      </div>
+      <div class="atom__body">
+        <div class="atom__head">
+          ${killBadge}
+          ${depsStr ? `<span class="atom__deps">depends on ${escapeHtml(depsStr)}</span>` : ''}
+        </div>
+        <p class="atom__content">${escapeHtml(node.content)}</p>
+      </div>
+    </article>
+  `;
+}
+
+function renderStage(stage, nodes, links, allNodes, killSet, killedHs) {
+  const stageNodes = nodes.filter(n => n.type === stage.type);
+  if (stageNodes.length === 0) return '';
+  const isFocus = stage.type === 'verification';
+  const isFinale = stage.type === 'conclusion';
+  const atoms = stageNodes.map(n => renderAtom(n, links, allNodes, killSet, killedHs)).join('');
+  const focusPill = isFocus
+    ? '<span class="stage__pill stage__pill--focus">where the V kills the H</span>'
+    : isFinale
+      ? '<span class="stage__pill stage__pill--finale">what survives</span>'
+      : '';
+
+  const cls = `stage stage--${stage.type}${isFocus ? ' stage--focus' : ''}${isFinale ? ' stage--finale' : ''}`;
+  return `
+    <section class="${cls}">
+      <header class="stage__header">
+        <span class="stage__chip stage__chip--${stage.type}"></span>
+        <h2 class="stage__title">${escapeHtml(stage.label)}</h2>
+        <span class="stage__count">${stageNodes.length}</span>
+        ${focusPill}
+      </header>
+      <div class="stage__atoms">${atoms}</div>
+    </section>
+  `;
+}
+
+function buildHtml(graph) {
+  const { title, nodes, links } = graph;
+  const verifiedCount = nodes.filter(n => n.type === 'verification').length;
+  const totalAtoms = nodes.length;
+  const avgConf = nodes.length ? Math.round((nodes.reduce((s, n) => s + (n.confidence ?? 0.7), 0) / nodes.length) * 100) : 0;
+  const maxDepth = Math.max(...nodes.map(n => n.depth ?? 0));
+
+  // Identify killing verifications via explicit `kills` field on V atoms.
+  const killSet = new Set();
+  const killedHs = new Set();
+  for (const v of nodes.filter(n => n.type === 'verification')) {
+    if (Array.isArray(v.kills) && v.kills.length > 0) {
+      killSet.add(v.id);
+      for (const h of v.kills) killedHs.add(h);
+    }
+  }
+
+  const stagesHtml = STAGES.map(s => renderStage(s, nodes, links, nodes, killSet, killedHs)).join('');
+
+  // Mini graph layout
+  const tiers = [
+    nodes.filter(n => n.type === 'premise'),
+    nodes.filter(n => n.type === 'reasoning'),
+    nodes.filter(n => n.type === 'hypothesis'),
+    nodes.filter(n => n.type === 'verification'),
+    nodes.filter(n => n.type === 'conclusion'),
+  ];
+  const W = 280, H = 320, padX = 22, padY = 24;
+  const usableW = W - padX * 2;
+  const usableH = H - padY * 2;
+  const tierHeight = usableH / Math.max(1, tiers.filter(t => t.length).length - 1);
+  const positions = new Map();
+  let visibleTier = 0;
+  tiers.forEach((tier) => {
+    if (tier.length === 0) return;
+    const y = padY + visibleTier * tierHeight;
+    tier.forEach((n, ni) => {
+      const x = padX + (usableW * (ni + 1)) / (tier.length + 1);
+      positions.set(n.id, { x, y });
+    });
+    visibleTier++;
+  });
+
+  const linksSvg = links.map(l => {
+    const a = positions.get(l.source), b = positions.get(l.target);
+    if (!a || !b) return '';
+    const isKill = killSet.has(l.target) && nodes.find(n => n.id === l.source && n.type === 'hypothesis');
+    return `<line x1="${a.x}" y1="${a.y}" x2="${b.x}" y2="${b.y}" class="link${isKill ? ' link--kill' : ''}"/>`;
+  }).join('');
+
+  const nodesSvg = nodes.map(n => {
+    const p = positions.get(n.id);
+    const isKilling = killSet.has(n.id);
+    const isKilledH = killedHs.has(n.id);
+    let cls = `node node--${n.type}`;
+    if (isKilledH) cls += ' node--killed-h';
+    if (isKilling) cls += ' node--killing';
+    return `
+      <g transform="translate(${p.x},${p.y})">
+        <circle class="${cls}" r="11"/>
+        <text class="node__label" text-anchor="middle" dy="0.32em">${escapeHtml(n.id)}</text>
+      </g>
+    `;
+  }).join('');
+
+  const titleParts = title.split('—').map(s => s.trim());
+  const headlineTitle = titleParts[0] || title;
+  const subtitle = titleParts[1] || '';
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>${escapeHtml(title)}</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+
+  :root {
+    --bg: #0a0e16;
+    --bg-elev: #11161f;
+    --bg-elev-2: #161c27;
+    --bg-focus: #0f1c24;
+    --bg-finale: #0c1c18;
+    --border: rgba(255, 255, 255, 0.07);
+    --border-strong: rgba(255, 255, 255, 0.14);
+    --border-focus: rgba(34, 211, 238, 0.45);
+    --border-finale: rgba(52, 211, 153, 0.45);
+
+    --fg: #eef0f3;
+    --fg-secondary: #a8aeb8;
+    --fg-muted: #6c727b;
+    --fg-faint: #3a3f48;
+
+    --premise: #94a3b8;
+    --reasoning: #60a5fa;
+    --hypothesis: #fbbf24;
+    --verification: #22d3ee;
+    --conclusion: #34d399;
+    --killed: #f87171;
+
+    --mono: 'SF Mono', 'Menlo', 'JetBrains Mono', monospace;
+    --sans: 'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Inter', sans-serif;
+  }
+
+  body {
+    background: var(--bg);
+    color: var(--fg);
+    font-family: var(--sans);
+    font-size: 14px;
+    line-height: 1.55;
+    min-height: 100vh;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  /* TITLE BAR */
+  .titlebar {
+    border-bottom: 1px solid var(--border);
+    padding: 16px 24px;
+    display: flex;
+    align-items: center;
+    gap: 24px;
+  }
+  .titlebar__left {
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
+  }
+  .titlebar__title {
+    font-size: 17px;
+    font-weight: 600;
+    letter-spacing: -0.02em;
+    color: var(--fg);
+  }
+  .titlebar__sep {
+    color: var(--fg-faint);
+    font-weight: 300;
+  }
+  .titlebar__pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px;
+    border-radius: 4px;
+    background: rgba(248, 113, 113, 0.10);
+    color: var(--killed);
+    font-family: var(--mono);
+    font-size: 11px;
+    font-weight: 500;
+    letter-spacing: 0.02em;
+  }
+  .titlebar__pill::before {
+    content: '×';
+    font-weight: 700;
+  }
+  .titlebar__stats {
+    margin-left: auto;
+    display: flex;
+    gap: 20px;
+  }
+  .titlebar__stat {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+  }
+  .titlebar__stat-value {
+    font-family: var(--mono);
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--fg);
+    font-variant-numeric: tabular-nums;
+    line-height: 1;
+  }
+  .titlebar__stat-label {
+    font-size: 10px;
+    color: var(--fg-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    margin-top: 4px;
+  }
+
+  /* LAYOUT */
+  .layout {
+    display: grid;
+    grid-template-columns: 320px 1fr;
+    min-height: calc(100vh - 65px);
+  }
+
+  /* GRAPH PANEL */
+  .graph-panel {
+    border-right: 1px solid var(--border);
+    padding: 24px 20px;
+    background: var(--bg);
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+  }
+  .graph-panel__heading {
+    font-size: 10px;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--fg-muted);
+    margin-bottom: 10px;
+  }
+  .graph-svg {
+    background: var(--bg-elev);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+  }
+  .link {
+    stroke: var(--fg-faint);
+    stroke-width: 0.8;
+    opacity: 0.5;
+  }
+  .link--kill {
+    stroke: var(--killed);
+    stroke-width: 1.2;
+    opacity: 0.85;
+    stroke-dasharray: 3 2;
+  }
+  .node--premise { fill: var(--premise); stroke: var(--premise); }
+  .node--reasoning { fill: var(--reasoning); stroke: var(--reasoning); }
+  .node--hypothesis { fill: var(--hypothesis); stroke: var(--hypothesis); }
+  .node--verification { fill: var(--verification); stroke: var(--verification); }
+  .node--conclusion { fill: var(--conclusion); stroke: var(--conclusion); }
+  .node--killed-h { fill: rgba(248, 113, 113, 0.10); stroke: var(--killed); stroke-dasharray: 2 2; }
+  .node--killing { stroke-width: 2.5; }
+  .node__label {
+    fill: var(--bg);
+    font-family: var(--mono);
+    font-size: 8px;
+    font-weight: 700;
+    pointer-events: none;
+    letter-spacing: -0.03em;
+  }
+  .node--killed-h + .node__label,
+  .node--killed-h .node__label { fill: var(--killed); }
+
+  /* LEGEND */
+  .legend {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 8px 12px;
+  }
+  .legend__row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 11px;
+    color: var(--fg-secondary);
+  }
+  .legend__chip {
+    width: 8px;
+    height: 8px;
+    border-radius: 2px;
+    flex-shrink: 0;
+  }
+  .legend__chip--premise { background: var(--premise); }
+  .legend__chip--reasoning { background: var(--reasoning); }
+  .legend__chip--hypothesis { background: var(--hypothesis); }
+  .legend__chip--verification { background: var(--verification); }
+  .legend__chip--conclusion { background: var(--conclusion); }
+
+  /* STAGES */
+  .stages {
+    padding: 24px 32px 48px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    max-width: 880px;
+  }
+
+  .stage {
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--bg-elev);
+    overflow: hidden;
+    transition: border-color 200ms cubic-bezier(0.25, 1, 0.5, 1);
+  }
+  .stage--focus {
+    border-color: var(--border-focus);
+    background: var(--bg-focus);
+    box-shadow: 0 0 0 1px rgba(34, 211, 238, 0.10);
+  }
+  .stage--finale {
+    border-color: var(--border-finale);
+    background: var(--bg-finale);
+    box-shadow: 0 0 0 1px rgba(52, 211, 153, 0.10);
+  }
+
+  .stage__header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--border);
+  }
+  .stage--focus .stage__header { border-color: rgba(34, 211, 238, 0.18); }
+  .stage--finale .stage__header { border-color: rgba(52, 211, 153, 0.18); }
+
+  .stage__chip {
+    width: 10px;
+    height: 10px;
+    border-radius: 2px;
+    flex-shrink: 0;
+  }
+  .stage__chip--premise { background: var(--premise); }
+  .stage__chip--reasoning { background: var(--reasoning); }
+  .stage__chip--hypothesis { background: var(--hypothesis); }
+  .stage__chip--verification { background: var(--verification); }
+  .stage__chip--conclusion { background: var(--conclusion); }
+
+  .stage__title {
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    color: var(--fg);
+  }
+  .stage__count {
+    font-family: var(--mono);
+    font-variant-numeric: tabular-nums;
+    font-size: 10px;
+    color: var(--fg-muted);
+    background: rgba(255, 255, 255, 0.05);
+    padding: 2px 6px;
+    border-radius: 3px;
+  }
+  .stage__pill {
+    margin-left: auto;
+    font-family: var(--mono);
+    font-size: 10px;
+    font-weight: 500;
+    padding: 3px 8px;
+    border-radius: 3px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+  .stage__pill--focus {
+    color: var(--verification);
+    background: rgba(34, 211, 238, 0.10);
+  }
+  .stage__pill--finale {
+    color: var(--conclusion);
+    background: rgba(52, 211, 153, 0.10);
+  }
+
+  .stage__atoms {
+    display: flex;
+    flex-direction: column;
+  }
+
+  /* ATOM */
+  .atom {
+    display: grid;
+    grid-template-columns: 88px 1fr;
+    gap: 16px;
+    padding: 14px 16px;
+    border-bottom: 1px solid var(--border);
+    transition: background 150ms cubic-bezier(0.25, 1, 0.5, 1);
+  }
+  .atom:last-child { border-bottom: none; }
+  .stage--focus .atom { border-color: rgba(34, 211, 238, 0.10); }
+  .stage--finale .atom { border-color: rgba(52, 211, 153, 0.10); }
+
+  /* Left rail: ID + confidence bar */
+  .atom__rail {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    align-items: flex-start;
+    padding-top: 1px;
+  }
+  .atom__id {
+    font-family: var(--mono);
+    font-size: 11px;
+    font-weight: 600;
+    padding: 2px 8px;
+    border-radius: 3px;
+    background: rgba(255, 255, 255, 0.06);
+    letter-spacing: 0;
+  }
+  .atom--premise .atom__id { color: var(--premise); }
+  .atom--reasoning .atom__id { color: var(--reasoning); }
+  .atom--hypothesis .atom__id { color: var(--hypothesis); }
+  .atom--verification .atom__id { color: var(--verification); }
+  .atom--conclusion .atom__id { color: var(--conclusion); }
+
+  .atom__conf-bar {
+    width: 64px;
+    height: 3px;
+    background: rgba(255, 255, 255, 0.05);
+    border-radius: 2px;
+    overflow: hidden;
+  }
+  .atom__conf-fill {
+    height: 100%;
+    background: var(--fg-faint);
+    transition: width 200ms;
+  }
+  .atom--premise .atom__conf-fill { background: var(--premise); opacity: 0.6; }
+  .atom--reasoning .atom__conf-fill { background: var(--reasoning); opacity: 0.6; }
+  .atom--hypothesis .atom__conf-fill { background: var(--hypothesis); opacity: 0.6; }
+  .atom--verification .atom__conf-fill { background: var(--verification); opacity: 0.7; }
+  .atom--conclusion .atom__conf-fill { background: var(--conclusion); opacity: 0.7; }
+  .atom--killing .atom__conf-fill { background: var(--killed); opacity: 0.85; }
+
+  .atom__conf-text {
+    font-family: var(--mono);
+    font-variant-numeric: tabular-nums;
+    font-size: 11px;
+    color: var(--fg-secondary);
+    letter-spacing: -0.02em;
+  }
+  .atom__conf-text .pct {
+    color: var(--fg-muted);
+    margin-left: 1px;
+  }
+
+  /* Body: head + content */
+  .atom__body {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    min-width: 0;
+  }
+  .atom__head {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+    min-height: 18px;
+  }
+  .atom__deps {
+    color: var(--fg-faint);
+    font-family: var(--mono);
+    font-size: 10px;
+    letter-spacing: 0;
+  }
+  .atom__content {
+    color: var(--fg);
+    font-size: 13px;
+    line-height: 1.6;
+    max-width: 68ch;
+  }
+
+  /* KILL markers */
+  .kill-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    color: var(--killed);
+    font-family: var(--mono);
+    font-size: 10.5px;
+    font-weight: 600;
+    background: rgba(248, 113, 113, 0.13);
+    padding: 3px 8px 3px 7px;
+    border-radius: 3px;
+    letter-spacing: 0.02em;
+  }
+  .kill-badge__arrow {
+    font-size: 13px;
+    line-height: 0.8;
+    margin-top: -1px;
+    font-weight: 700;
+  }
+  .kill-badge strong {
+    color: #fca5a5;
+    font-weight: 700;
+    margin-left: 1px;
+  }
+
+  .killed-badge {
+    color: var(--killed);
+    font-family: var(--mono);
+    font-size: 10px;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    background: rgba(248, 113, 113, 0.08);
+    padding: 2px 6px;
+    border-radius: 3px;
+    opacity: 0.85;
+  }
+
+  /* killing V atom: red left bar */
+  .atom--killing {
+    background: rgba(248, 113, 113, 0.04);
+    box-shadow: inset 2px 0 0 var(--killed);
+  }
+  /* killed H atom: dimmed content + strikethrough hint */
+  .atom--killed {
+    opacity: 0.55;
+  }
+  .atom--killed .atom__content {
+    color: var(--fg-secondary);
+  }
+
+  /* Conclusion emphasis */
+  .stage--finale .atom__content {
+    font-size: 14px;
+    line-height: 1.6;
+    color: var(--fg);
+    font-weight: 450;
+  }
+  .stage--finale .atom__id {
+    background: rgba(52, 211, 153, 0.10);
+  }
+</style>
+</head>
+<body>
+
+<header class="titlebar">
+  <div class="titlebar__left">
+    <h1 class="titlebar__title">${escapeHtml(headlineTitle)}</h1>
+    ${subtitle ? `<span class="titlebar__sep">·</span><span class="titlebar__pill">${escapeHtml(subtitle)}</span>` : ''}
+  </div>
+  <div class="titlebar__stats">
+    <div class="titlebar__stat"><span class="titlebar__stat-value">${avgConf}<span style="color: var(--fg-muted); font-size: 10px;">%</span></span><span class="titlebar__stat-label">avg conf</span></div>
+    <div class="titlebar__stat"><span class="titlebar__stat-value">${totalAtoms}</span><span class="titlebar__stat-label">atoms</span></div>
+    <div class="titlebar__stat"><span class="titlebar__stat-value">${verifiedCount}</span><span class="titlebar__stat-label">verifications</span></div>
+    <div class="titlebar__stat"><span class="titlebar__stat-value">${maxDepth}</span><span class="titlebar__stat-label">depth</span></div>
+  </div>
+</header>
+
+<div class="layout">
+  <aside class="graph-panel">
+    <div>
+      <div class="graph-panel__heading">graph</div>
+      <svg class="graph-svg" viewBox="0 0 ${W} ${H}" width="100%">
+        ${linksSvg}
+        ${nodesSvg}
+      </svg>
+    </div>
+
+    <div>
+      <div class="graph-panel__heading">atom types</div>
+      <div class="legend">
+        <div class="legend__row"><span class="legend__chip legend__chip--premise"></span>premise</div>
+        <div class="legend__row"><span class="legend__chip legend__chip--reasoning"></span>reasoning</div>
+        <div class="legend__row"><span class="legend__chip legend__chip--hypothesis"></span>hypothesis</div>
+        <div class="legend__row"><span class="legend__chip legend__chip--verification"></span>verification</div>
+        <div class="legend__row"><span class="legend__chip legend__chip--conclusion"></span>conclusion</div>
+      </div>
+    </div>
+
+    <div>
+      <div class="graph-panel__heading">key</div>
+      <div style="display: flex; flex-direction: column; gap: 8px; font-size: 11px; color: var(--fg-secondary);">
+        <div style="display: flex; align-items: center; gap: 8px;">
+          <span style="display:inline-block; width: 16px; height: 2px; background: var(--killed); border-radius: 1px;"></span>
+          kill link
+        </div>
+        <div style="display: flex; align-items: center; gap: 8px;">
+          <span style="display:inline-block; width: 8px; height: 8px; border-radius: 50%; border: 2px dashed var(--killed); background: rgba(248,113,113,0.10);"></span>
+          eliminated
+        </div>
+        <div style="display: flex; align-items: center; gap: 8px;">
+          <span style="display:inline-block; width: 8px; height: 8px; border-radius: 50%; background: var(--verification); border: 2px solid var(--verification); box-shadow: 0 0 0 1px rgba(255,255,255,0.2);"></span>
+          killing V
+        </div>
+      </div>
+    </div>
+  </aside>
+
+  <main class="stages">
+    ${stagesHtml}
+  </main>
+</div>
+
+</body>
+</html>`;
+}
+
+const [, , inputArg, outputArg] = process.argv;
+if (!inputArg) {
+  console.error('Usage: node render-review.mjs <input.json> [output.html]');
+  process.exit(1);
+}
+
+const inputPath = resolve(inputArg);
+const outputPath = outputArg
+  ? resolve(outputArg)
+  : join(dirname(inputPath), basename(inputPath, '.json') + '-review.html');
+
+const data = JSON.parse(readFileSync(inputPath, 'utf-8'));
+writeFileSync(outputPath, buildHtml(data));
+console.log(`wrote ${outputPath}`);

--- a/tests/examples.test.ts
+++ b/tests/examples.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { execSync } from 'node:child_process';
+import { existsSync, readFileSync, unlinkSync } from 'node:fs';
+import * as path from 'node:path';
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const EXAMPLES = path.join(REPO_ROOT, 'examples');
+const INPUT = path.join(EXAMPLES, 'example-trace.json');
+
+const REVIEW_OUT = path.join(EXAMPLES, 'example-trace-review.html');
+const FOCUS_OUT = path.join(EXAMPLES, 'example-trace-focus.html');
+
+afterEach(() => {
+  for (const f of [REVIEW_OUT, FOCUS_OUT]) {
+    if (existsSync(f)) unlinkSync(f);
+  }
+});
+
+describe('examples/', () => {
+  it('example-trace.json is valid JSON with the expected graph shape', () => {
+    const raw = readFileSync(INPUT, 'utf-8');
+    const data = JSON.parse(raw);
+    expect(data).toHaveProperty('title');
+    expect(Array.isArray(data.nodes)).toBe(true);
+    expect(Array.isArray(data.links)).toBe(true);
+    expect(data.nodes.length).toBeGreaterThan(0);
+    // At least one verification atom should carry a `kills` field for the demo.
+    const killingV = data.nodes.find(
+      (n: { type: string; kills?: string[] }) =>
+        n.type === 'verification' && Array.isArray(n.kills) && n.kills.length > 0,
+    );
+    expect(killingV).toBeDefined();
+  });
+
+  it('render-review.mjs produces non-empty HTML against the example', () => {
+    execSync(`node ${path.join(EXAMPLES, 'render-review.mjs')} ${INPUT}`, {
+      cwd: REPO_ROOT,
+      stdio: 'pipe',
+    });
+    expect(existsSync(REVIEW_OUT)).toBe(true);
+    const html = readFileSync(REVIEW_OUT, 'utf-8');
+    expect(html.length).toBeGreaterThan(1000);
+    expect(html).toContain('<!DOCTYPE html>');
+    // The kill marker for the killing V atom should render.
+    expect(html.toLowerCase()).toContain('kills');
+  });
+
+  it('render-focus.mjs produces non-empty HTML against the example', () => {
+    execSync(`node ${path.join(EXAMPLES, 'render-focus.mjs')} ${INPUT}`, {
+      cwd: REPO_ROOT,
+      stdio: 'pipe',
+    });
+    expect(existsSync(FOCUS_OUT)).toBe(true);
+    const html = readFileSync(FOCUS_OUT, 'utf-8');
+    expect(html.length).toBeGreaterThan(500);
+    expect(html).toContain('<!DOCTYPE html>');
+    // The focus viewer should surface the kill banner.
+    expect(html).toContain('KILLS');
+  });
+});


### PR DESCRIPTION
## Description

Adds an `examples/` directory with two standalone HTML viewers for atom-graph exports, complementing the default D3 force-graph in `src/visualization.ts`.

**Why:** the default viewer is great for interactive exploration, but is awkward when you want a long-form text view of a trace — for async review, documentation, or anywhere clicking around isn't an option. These two viewers consume the unchanged JSON from `atomcommands export` and render the same data differently.

**`render-review.mjs`** — small graph in a left rail, stage-by-stage atom content as the main column. Stages stacked top-to-bottom (P→R→H→V→C). Verifications stage gets a focus treatment. Killed hypotheses are dimmed.

**`render-focus.mjs`** — Verifications + Conclusion only, full-bleed. A single-frame summary of what the trace caught and what survived.

Both viewers additionally honor optional `kills: string[]` / `confirms: string[]` fields on verification atoms to highlight the V→H relationships explicitly. The default D3 viewer ignores these fields, so adding them is non-breaking — you can put them in your export JSON and the existing viz still works fine.

`examples/example-trace.json` is a synthetic trace ("serverless function → Postgres connection strategy") that exercises all five atom types and the kills/confirms fields.

Generated outputs (`*-review.html`, `*-focus.html`) are gitignored.

## Checklist

- [x] Description clearly explains the change
- [x] Tests added or updated — `tests/examples.test.ts` (3 tests, smoke-tests both renderers against the example trace)
- [x] `npm test` passes (186 tests)
- [x] `npm run build` succeeds
- [x] Documentation updated — `examples/README.md` covers usage; CHANGELOG `[Unreleased]` entry added

## Try it

```bash
node examples/render-review.mjs examples/example-trace.json
node examples/render-focus.mjs examples/example-trace.json
# Open the generated HTML in a browser.
```